### PR TITLE
QuestionService: add Question entity, repository, and basic save test

### DIFF
--- a/server/src/main/java/com/g13cs3219/server/model/Question.java
+++ b/server/src/main/java/com/g13cs3219/server/model/Question.java
@@ -1,0 +1,137 @@
+package com.g13cs3219.server.model;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "question")
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long questionId;
+
+    private String title;
+
+    private String topic;
+
+    @Column(columnDefinition = "TEXT")
+    private String prompt;
+
+    @ElementCollection
+    private List<String> example;
+
+    @ElementCollection
+    private List<String> constraints;
+
+    @ElementCollection
+    private List<String> imageUrls;
+
+    private Long createdBy;
+
+    private LocalDateTime createdAt;
+
+    private Long updatedBy;
+
+    private LocalDateTime updatedAt;
+
+    private Boolean isActive = true;
+
+    public Long getQuestionId() {
+        return questionId;
+    }
+
+    public void setQuestionId(Long questionId) {
+        this.questionId = questionId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public List<String> getExample() {
+        return example;
+    }
+
+    public void setExample(List<String> example) {
+        this.example = example;
+    }
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    public void setPrompt(String prompt) {
+        this.prompt = prompt;
+    }
+
+    public List<String> getConstraints() {
+        return constraints;
+    }
+
+    public void setConstraints(List<String> constraints) {
+        this.constraints = constraints;
+    }
+
+    public List<String> getImageUrls() {
+        return imageUrls;
+    }
+
+    public void setImageUrls(List<String> imageUrls) {
+        this.imageUrls = imageUrls;
+    }
+
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Long getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(Long updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+}

--- a/server/src/main/java/com/g13cs3219/server/repository/QuestionRepository.java
+++ b/server/src/main/java/com/g13cs3219/server/repository/QuestionRepository.java
@@ -1,0 +1,13 @@
+package com.g13cs3219.server.repository;
+
+import com.g13cs3219.server.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findByTopicAndIsActiveTrue(String topic);
+    List<Question> findByTopicAndIsActiveTrueAndTitleContainingIgnoreCase(String topic, String title);
+}

--- a/server/src/test/java/com/g13cs3219/server/QuestionRepositoryTest.java
+++ b/server/src/test/java/com/g13cs3219/server/QuestionRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.g13cs3219.server;
+
+import com.g13cs3219.server.model.Question;
+import com.g13cs3219.server.repository.QuestionRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class QuestionRepositoryTest {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Test
+    void testSaveQuestion() {
+        Question question = new Question();
+        question.setTitle("Test Question");
+        question.setTopic("Algorithms");
+        question.setPrompt("Write a function that sums two numbers");
+        question.setExample(List.of("Example 1"));
+        question.setConstraints(List.of("No constraints"));
+        question.setImageUrls(List.of());
+        question.setCreatedAt(LocalDateTime.now());
+        question.setCreatedBy(1L);
+        question.setIsActive(true);
+
+        Question saved = questionRepository.save(question);
+
+        assertNotNull(saved.getQuestionId(), "QuestionId mock test successfully");
+    }
+}


### PR DESCRIPTION
### What
- Added Question entity with fields: `questionId, title, topic, prompt, example, constraints, imageUrls, createdBy, createdAt, updatedBy, updatedAt, isActive.`
- Added QuestionRepository with basic query methods: `findByTopicAndIsActiveTrue() `and `findByTopicAndIsActiveTrueAndTitleContainingIgnoreCase().`
- Added basic QuestionRepositoryTest to test saving a Question object.

### Why
- Enables early integration testing and progress demo for D2 milestone.
- Ensures that CRUD operations and query patterns can be developed 