### PR TITLE
Implement CRUD for Question Service (No Admin role)

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -46,11 +46,21 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.21.1</version>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.21.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/server/src/main/java/com/g13cs3219/server/config/ExceptionMsg.java
+++ b/server/src/main/java/com/g13cs3219/server/config/ExceptionMsg.java
@@ -1,0 +1,43 @@
+package com.g13cs3219.server.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Converts exceptions into a consistent JSON error body:
+ * { "timestamp": "...", "status": 404, "error": "Not Found", "message": "..." }
+ */
+@RestControllerAdvice
+public class ExceptionMsg {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatus(ResponseStatusException ex) {
+        return buildError(ex.getStatusCode().value(), ex.getReason());
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, Object>> handleAccessDenied(AccessDeniedException ex) {
+        return buildError(HttpStatus.FORBIDDEN.value(), "Access denied.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGeneric(Exception ex) {
+        return buildError(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Unexpected server error.");
+    }
+
+    private ResponseEntity<Map<String, Object>> buildError(int status, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", status);
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/server/src/main/java/com/g13cs3219/server/config/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/g13cs3219/server/config/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
-
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,7 +15,7 @@ import java.util.Map;
  * { "timestamp": "...", "status": 404, "error": "Not Found", "message": "..." }
  */
 @RestControllerAdvice
-public class ExceptionMsg {
+public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<Map<String, Object>> handleResponseStatus(ResponseStatusException ex) {
@@ -37,6 +36,10 @@ public class ExceptionMsg {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", status);
+        HttpStatus httpStatus = HttpStatus.resolve(status);
+        if (httpStatus != null) {
+            body.put("error", httpStatus.getReasonPhrase());
+        }
         body.put("message", message);
         return ResponseEntity.status(status).body(body);
     }

--- a/server/src/main/java/com/g13cs3219/server/config/RoleConfig.java
+++ b/server/src/main/java/com/g13cs3219/server/config/RoleConfig.java
@@ -1,0 +1,31 @@
+package com.g13cs3219.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class RoleConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET,  "/questions",     "/questions/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/questions/match").permitAll()
+                        // .anyRequest().authenticated() (change to this when JWWT integrate)
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}

--- a/server/src/main/java/com/g13cs3219/server/config/RoleConfig.java
+++ b/server/src/main/java/com/g13cs3219/server/config/RoleConfig.java
@@ -23,7 +23,7 @@ public class RoleConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,  "/questions",     "/questions/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/questions/match").permitAll()
-                        // .anyRequest().authenticated() (change to this when JWWT integrate)
+                        // .anyRequest().authenticated() (change to this when JWT integrate)
                         .anyRequest().permitAll()
                 );
         return http.build();

--- a/server/src/main/java/com/g13cs3219/server/controller/QuestionController.java
+++ b/server/src/main/java/com/g13cs3219/server/controller/QuestionController.java
@@ -73,6 +73,6 @@ public class QuestionController {
 
     private Long getCallerUserId() {
         // wait for JWT integration
-        return 0L;
+        return null;
     }
 }

--- a/server/src/main/java/com/g13cs3219/server/controller/QuestionController.java
+++ b/server/src/main/java/com/g13cs3219/server/controller/QuestionController.java
@@ -1,0 +1,78 @@
+package com.g13cs3219.server.controller;
+
+import com.g13cs3219.server.dto.MatchRequest;
+import com.g13cs3219.server.dto.QuestionRequest;
+import com.g13cs3219.server.dto.QuestionResponse;
+import com.g13cs3219.server.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/questions")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*")
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getQuestions(
+            @RequestParam(required = false) String topic,
+            @RequestParam(required = false) String difficulty) {
+
+        List<QuestionResponse> questions = questionService.getQuestions(topic, difficulty);
+        return ResponseEntity.ok(Map.of("questions", questions));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Map<String, Object>> getQuestionById(@PathVariable Long id) {
+        QuestionResponse question = questionService.getQuestionById(id);
+        return ResponseEntity.ok(Map.of("question", question));
+    }
+
+    @PostMapping
+//    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String, Object>> createQuestion(
+            @RequestBody QuestionRequest req) {
+        Long createdBy = getCallerUserId();
+        Long questionId = questionService.createQuestion(req, createdBy);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("questionId", questionId));
+    }
+
+    @PutMapping("/{id}")
+//    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> updateQuestion(
+            @PathVariable Long id,
+            @RequestBody QuestionRequest req) {
+
+        Long updatedBy = getCallerUserId();
+        questionService.updateQuestion(id, req, updatedBy);
+        return ResponseEntity.ok("Question updated successfully");
+    }
+
+    @DeleteMapping("/{id}")
+//    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> deleteQuestion(@PathVariable Long id) {
+        questionService.deleteQuestion(id);
+        return ResponseEntity.ok("Question deleted successfully");
+    }
+
+    @PostMapping("/match")
+    public ResponseEntity<Map<String, Object>> matchQuestion(
+            @RequestBody MatchRequest req) {
+
+        QuestionResponse question = questionService.matchQuestion(req.getTopic(), req.getDifficulty());
+        return ResponseEntity.ok(Map.of("question", question));
+    }
+
+    private Long getCallerUserId() {
+        // wait for JWT integration
+        return 0L;
+    }
+}

--- a/server/src/main/java/com/g13cs3219/server/converter/StringListConverter.java
+++ b/server/src/main/java/com/g13cs3219/server/converter/StringListConverter.java
@@ -1,0 +1,40 @@
+package com.g13cs3219.server.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "[]";
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            return "[]";
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new ArrayList<>();
+        }
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<List<String>>() {});
+        } catch (JsonProcessingException e) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/server/src/main/java/com/g13cs3219/server/converter/StringListConverter.java
+++ b/server/src/main/java/com/g13cs3219/server/converter/StringListConverter.java
@@ -22,7 +22,7 @@ public class StringListConverter implements AttributeConverter<List<String>, Str
         try {
             return objectMapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
-            return "[]";
+            throw new RuntimeException("Failed to serialize List<String> to JSON", e);
         }
     }
 
@@ -34,7 +34,7 @@ public class StringListConverter implements AttributeConverter<List<String>, Str
         try {
             return objectMapper.readValue(dbData, new TypeReference<List<String>>() {});
         } catch (JsonProcessingException e) {
-            return new ArrayList<>();
+            throw new RuntimeException("Failed to deserialize JSON to List<String>", e);
         }
     }
 }

--- a/server/src/main/java/com/g13cs3219/server/dto/MatchRequest.java
+++ b/server/src/main/java/com/g13cs3219/server/dto/MatchRequest.java
@@ -1,0 +1,9 @@
+package com.g13cs3219.server.dto;
+
+import lombok.Data;
+
+@Data
+public class MatchRequest {
+    private String topic;
+    private String difficulty;
+}

--- a/server/src/main/java/com/g13cs3219/server/dto/QuestionRequest.java
+++ b/server/src/main/java/com/g13cs3219/server/dto/QuestionRequest.java
@@ -1,7 +1,6 @@
 package com.g13cs3219.server.dto;
 
 import lombok.Data;
-import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -10,7 +9,7 @@ public class QuestionRequest {
     private String topic;
     private String difficulty;
     private String prompt;
-    private List<String> example    = new ArrayList<>();
-    private List<String> constraints = new ArrayList<>();
-    private List<String> imageUrls  = new ArrayList<>();
+    private List<String> example;
+    private List<String> constraints;
+    private List<String> imageUrls;
 }

--- a/server/src/main/java/com/g13cs3219/server/dto/QuestionRequest.java
+++ b/server/src/main/java/com/g13cs3219/server/dto/QuestionRequest.java
@@ -1,0 +1,16 @@
+package com.g13cs3219.server.dto;
+
+import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class QuestionRequest {
+    private String title;
+    private String topic;
+    private String difficulty;
+    private String prompt;
+    private List<String> example    = new ArrayList<>();
+    private List<String> constraints = new ArrayList<>();
+    private List<String> imageUrls  = new ArrayList<>();
+}

--- a/server/src/main/java/com/g13cs3219/server/dto/QuestionResponse.java
+++ b/server/src/main/java/com/g13cs3219/server/dto/QuestionResponse.java
@@ -1,0 +1,40 @@
+package com.g13cs3219.server.dto;
+
+import com.g13cs3219.server.model.Question;
+import lombok.Data;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class QuestionResponse {
+
+    private Long questionId;
+    private String title;
+    private String topic;
+    private String difficulty;
+    private String prompt;
+    private List<String> example;
+    private List<String> constraints;
+    private List<String> imageUrls;
+    private Long createdBy;
+    private LocalDateTime createdAt;
+    private Long updatedBy;
+    private LocalDateTime updatedAt;
+
+    public static QuestionResponse from(Question q) {
+        QuestionResponse dto = new QuestionResponse();
+        dto.setQuestionId(q.getQuestionId());
+        dto.setTitle(q.getTitle());
+        dto.setTopic(q.getTopic());
+        dto.setDifficulty(q.getDifficulty());
+        dto.setPrompt(q.getPrompt());
+        dto.setExample(q.getExample());
+        dto.setConstraints(q.getConstraints());
+        dto.setImageUrls(q.getImageUrls());
+        dto.setCreatedBy(q.getCreatedBy());
+        dto.setCreatedAt(q.getCreatedAt());
+        dto.setUpdatedBy(q.getUpdatedBy());
+        dto.setUpdatedAt(q.getUpdatedAt());
+        return dto;
+    }
+}

--- a/server/src/main/java/com/g13cs3219/server/model/Question.java
+++ b/server/src/main/java/com/g13cs3219/server/model/Question.java
@@ -26,7 +26,7 @@ public class Question {
     @Column(name = "question_id")
     private Long questionId;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false) //unique = true
     private String title;
 
     @Column(nullable = false)

--- a/server/src/main/java/com/g13cs3219/server/model/Question.java
+++ b/server/src/main/java/com/g13cs3219/server/model/Question.java
@@ -1,0 +1,70 @@
+package com.g13cs3219.server.model;
+
+import com.g13cs3219.server.converter.StringListConverter;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "questions")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id")
+    private Long questionId;
+
+    @Column(nullable = false, unique = true)
+    private String title;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(nullable = false)
+    private String difficulty;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String prompt;
+
+    @Convert(converter = StringListConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private List<String> example = new ArrayList<>();
+
+    @Convert(converter = StringListConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private List<String> constraints = new ArrayList<>();
+
+    @Convert(converter = StringListConverter.class)
+    @Column(name = "image_urls", columnDefinition = "TEXT")
+    private List<String> imageUrls = new ArrayList<>();
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder.Default
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+}

--- a/server/src/main/java/com/g13cs3219/server/repository/QuestionRepository.java
+++ b/server/src/main/java/com/g13cs3219/server/repository/QuestionRepository.java
@@ -1,0 +1,28 @@
+package com.g13cs3219.server.repository;
+
+import com.g13cs3219.server.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    List<Question> findByIsActiveTrue();
+    List<Question> findByTopicIgnoreCaseAndIsActiveTrue(String topic);
+    List<Question> findByDifficultyIgnoreCaseAndIsActiveTrue(String difficulty);
+    List<Question> findByTopicIgnoreCaseAndDifficultyIgnoreCaseAndIsActiveTrue(String topic, String difficulty);
+    Optional<Question> findByQuestionIdAndIsActiveTrue(Long questionId);
+    @Query(value = "SELECT * FROM questions WHERE LOWER(topic) = LOWER(:topic) " +
+            "AND LOWER(difficulty) = LOWER(:difficulty) " +
+            "AND is_active = true ORDER BY RANDOM() LIMIT 1",
+            nativeQuery = true)
+    Optional<Question> findRandomByTopicAndDifficulty(@Param("topic") String topic,
+                                                      @Param("difficulty") String difficulty);
+
+    boolean existsByTitleIgnoreCaseAndIsActiveTrue(String title);
+}

--- a/server/src/main/java/com/g13cs3219/server/service/QuestionService.java
+++ b/server/src/main/java/com/g13cs3219/server/service/QuestionService.java
@@ -11,11 +11,29 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Service layer for the Question Service.
+ *
+ * Handles all business logic for managing the question repository,
+ * including CRUD operations and question matching for the Matching Service.
+ * All queries are scoped to active questions only (isActive = true).
+ */
 @Service
 @RequiredArgsConstructor
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
+    /**
+     * Retrieves all active questions, with optional filtering by topic and/or difficulty.
+     *
+     * - If both topic and difficulty are provided, filters by both.
+     * - If only one is provided, filters by that field only.
+     * - If neither is provided, returns all active questions.
+     *
+     * @param topic      optional topic filter (case-insensitive), e.g. "Arrays"
+     * @param difficulty optional difficulty filter (case-insensitive), e.g. "easy"
+     * @return list of matching active questions as response DTOs
+     */
     public List<QuestionResponse> getQuestions(String topic, String difficulty) {
         List<Question> questions;
 
@@ -36,14 +54,32 @@ public class QuestionService {
                 .map(QuestionResponse::from)
                 .collect(Collectors.toList());
     }
-
+    /**
+     * Retrieves a single active question by its ID.
+     *
+     * @param id the question's primary key
+     * @return the question as a response DTO
+     * @throws ResponseStatusException 404 if no active question exists with the given ID
+     */
     public QuestionResponse getQuestionById(Long id) {
         Question question = questionRepository.findByQuestionIdAndIsActiveTrue(id)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "Question not found with id: " + id));
         return QuestionResponse.from(question);
     }
-
+    /**
+     * Creates a new question and persists it to the database.
+     *
+     * Validates that all required fields (title, topic, difficulty, prompt) are present
+     * and that difficulty is one of: easy, medium, hard.
+     * Also checks that no active question with the same title already exists.
+     *
+     * @param req       the request body containing question details
+     * @param createdBy the userId of the admin performing the action
+     * @return the generated questionId of the newly created question
+     * @throws ResponseStatusException 400 if required fields are missing or difficulty is invalid
+     * @throws ResponseStatusException 409 if a question with the same title already exists
+     */
     public Long createQuestion(QuestionRequest req, Long createdBy) {
         validateRequired(req);
         validateDifficulty(req.getDifficulty());
@@ -82,12 +118,12 @@ public class QuestionService {
             }
             question.setTitle(req.getTitle());
         }
-        if (req.getTopic()      != null) question.setTopic(req.getTopic());
+        if (req.getTopic()      != null && !req.getTopic().isBlank())  question.setTopic(req.getTopic());
         if (req.getDifficulty() != null) {
             validateDifficulty(req.getDifficulty());
             question.setDifficulty(req.getDifficulty().toLowerCase());
         }
-        if (req.getPrompt()      != null) question.setPrompt(req.getPrompt());
+        if (req.getPrompt()      != null && !req.getPrompt().isBlank())  question.setPrompt(req.getPrompt());
         if (req.getExample()     != null) question.setExample(req.getExample());
         if (req.getConstraints() != null) question.setConstraints(req.getConstraints());
         if (req.getImageUrls()   != null) question.setImageUrls(req.getImageUrls());
@@ -95,7 +131,16 @@ public class QuestionService {
         question.setUpdatedBy(updatedBy);
         questionRepository.save(question);
     }
-
+    /**
+     * Soft deletes a question by setting its isActive flag to false.
+     *
+     * The record is retained in the database to preserve referential integrity
+     * with the History table
+     * Soft-deleted questions are excluded from all other queries.
+     *
+     * @param id the ID of the question to delete
+     * @throws ResponseStatusException 404 if no active question exists with the given ID
+     */
     public void deleteQuestion(Long id) {
         Question question = questionRepository.findByQuestionIdAndIsActiveTrue(id)
                 .orElseThrow(() -> new ResponseStatusException(
@@ -109,15 +154,24 @@ public class QuestionService {
      * the given topic + difficulty.
      */
     public QuestionResponse matchQuestion(String topic, String difficulty) {
+        String normalizedTopic = (topic == null) ? null : topic.trim();
+        if (normalizedTopic == null || normalizedTopic.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "topic is required.");
+        }
         validateDifficulty(difficulty);
-
-        return questionRepository.findRandomByTopicAndDifficulty(topic, difficulty)
+        return questionRepository.findRandomByTopicAndDifficulty(normalizedTopic, difficulty)
                 .map(QuestionResponse::from)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,
-                        "No question found for topic='" + topic + "' difficulty='" + difficulty + "'"));
+                        "No question found for topic='" + normalizedTopic + "' difficulty='" + difficulty + "'"));
     }
-
+    /**
+     * Validates that all required fields for creating a question are present and non-blank.
+     *
+     * @param req the question creation request
+     * @throws ResponseStatusException 400 if any required field is missing
+     */
     private void validateRequired(QuestionRequest req) {
         if (req.getTitle()      == null || req.getTitle().isBlank()  ||
                 req.getTopic()      == null || req.getTopic().isBlank()  ||
@@ -127,8 +181,17 @@ public class QuestionService {
                     "title, topic, difficulty and prompt are required.");
         }
     }
-
+    /**
+     * Validates that the difficulty value is one of the accepted values.
+     *
+     * @param difficulty the difficulty string to validate
+     * @throws ResponseStatusException 400 if the value is not easy, medium, or hard
+     */
     private void validateDifficulty(String difficulty) {
+        if (difficulty == null || difficulty.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "difficulty is required and must be one of: easy, medium, hard");
+        }
         if (!List.of("easy", "medium", "hard").contains(difficulty.toLowerCase())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     "difficulty must be one of: easy, medium, hard");

--- a/server/src/main/java/com/g13cs3219/server/service/QuestionService.java
+++ b/server/src/main/java/com/g13cs3219/server/service/QuestionService.java
@@ -1,0 +1,137 @@
+package com.g13cs3219.server.service;
+
+import com.g13cs3219.server.dto.QuestionRequest;
+import com.g13cs3219.server.dto.QuestionResponse;
+import com.g13cs3219.server.model.Question;
+import com.g13cs3219.server.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+    public List<QuestionResponse> getQuestions(String topic, String difficulty) {
+        List<Question> questions;
+
+        boolean hasTopic      = topic      != null && !topic.isBlank();
+        boolean hasDifficulty = difficulty != null && !difficulty.isBlank();
+
+        if (hasTopic && hasDifficulty) {
+            questions = questionRepository.findByTopicIgnoreCaseAndDifficultyIgnoreCaseAndIsActiveTrue(topic, difficulty);
+        } else if (hasTopic) {
+            questions = questionRepository.findByTopicIgnoreCaseAndIsActiveTrue(topic);
+        } else if (hasDifficulty) {
+            questions = questionRepository.findByDifficultyIgnoreCaseAndIsActiveTrue(difficulty);
+        } else {
+            questions = questionRepository.findByIsActiveTrue();
+        }
+
+        return questions.stream()
+                .map(QuestionResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public QuestionResponse getQuestionById(Long id) {
+        Question question = questionRepository.findByQuestionIdAndIsActiveTrue(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Question not found with id: " + id));
+        return QuestionResponse.from(question);
+    }
+
+    public Long createQuestion(QuestionRequest req, Long createdBy) {
+        validateRequired(req);
+        validateDifficulty(req.getDifficulty());
+
+        if (questionRepository.existsByTitleIgnoreCaseAndIsActiveTrue(req.getTitle())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "A question with this title already exists.");
+        }
+
+        Question question = Question.builder()
+                .title(req.getTitle())
+                .topic(req.getTopic())
+                .difficulty(req.getDifficulty().toLowerCase())
+                .prompt(req.getPrompt())
+                .example(req.getExample())
+                .constraints(req.getConstraints())
+                .imageUrls(req.getImageUrls())
+                .createdBy(createdBy)
+                .updatedBy(createdBy)
+                .isActive(true)
+                .build();
+
+        Question saved = questionRepository.save(question);
+        return saved.getQuestionId();
+    }
+    public void updateQuestion(Long id, QuestionRequest req, Long updatedBy) {
+        Question question = questionRepository.findByQuestionIdAndIsActiveTrue(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Question not found with id: " + id));
+
+        if (req.getTitle() != null && !req.getTitle().isBlank()) {
+            if (!req.getTitle().equalsIgnoreCase(question.getTitle())
+                    && questionRepository.existsByTitleIgnoreCaseAndIsActiveTrue(req.getTitle())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "A question with this title already exists.");
+            }
+            question.setTitle(req.getTitle());
+        }
+        if (req.getTopic()      != null) question.setTopic(req.getTopic());
+        if (req.getDifficulty() != null) {
+            validateDifficulty(req.getDifficulty());
+            question.setDifficulty(req.getDifficulty().toLowerCase());
+        }
+        if (req.getPrompt()      != null) question.setPrompt(req.getPrompt());
+        if (req.getExample()     != null) question.setExample(req.getExample());
+        if (req.getConstraints() != null) question.setConstraints(req.getConstraints());
+        if (req.getImageUrls()   != null) question.setImageUrls(req.getImageUrls());
+
+        question.setUpdatedBy(updatedBy);
+        questionRepository.save(question);
+    }
+
+    public void deleteQuestion(Long id) {
+        Question question = questionRepository.findByQuestionIdAndIsActiveTrue(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Question not found with id: " + id));
+
+        question.setIsActive(false);
+        questionRepository.save(question);
+    }
+    /**
+     * Used by Matching Service: returns one random question matching
+     * the given topic + difficulty.
+     */
+    public QuestionResponse matchQuestion(String topic, String difficulty) {
+        validateDifficulty(difficulty);
+
+        return questionRepository.findRandomByTopicAndDifficulty(topic, difficulty)
+                .map(QuestionResponse::from)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "No question found for topic='" + topic + "' difficulty='" + difficulty + "'"));
+    }
+
+    private void validateRequired(QuestionRequest req) {
+        if (req.getTitle()      == null || req.getTitle().isBlank()  ||
+                req.getTopic()      == null || req.getTopic().isBlank()  ||
+                req.getDifficulty() == null || req.getDifficulty().isBlank() ||
+                req.getPrompt()     == null || req.getPrompt().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "title, topic, difficulty and prompt are required.");
+        }
+    }
+
+    private void validateDifficulty(String difficulty) {
+        if (!List.of("easy", "medium", "hard").contains(difficulty.toLowerCase())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "difficulty must be one of: easy, medium, hard");
+        }
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+server.port=8080


### PR DESCRIPTION
### What
Implements the Question Service  providing a API to manage the question repository. Includes full CRUD operations for questions and a dedicated match endpoint.
`GET /questions`: list all active questions, supports filtering by topic and difficulty
`GET /questions/{id}`: retrieve a single question by ID
`POST /questions`: create a new question (Admin only)
`PUT /questions/{id}`:  update an existing question (Admin only)
`DELETE /questions/{id}`: soft delete a question (Admin only)
`POST /questions/match`: return a random question matching a given topic and difficulty, intended for the Matching Service
### Solution

- List<String> fields (example, constraints, imageUrls) are persisted as JSON text via `StringListConverter`, avoiding a separate join table
- Delete is implemented as a soft delete (`isActive = false`) so question history is preserved for the History table 
- `POST /questions/match` uses a native ORDER BY RANDOM() query to return one question matching topic + difficulty 
- `RoleConfig` is set up with role based access (@PreAuthorize("hasRole('ADMIN')") currently disabled pending JWT integration with User Service
- `ExceptionMsg `returns consistent JSON error responses across all endpoints
### Test Plan

- POST:  `http://localhost:8080/questions`

{
  "title": "Two Sum 2",
  "topic": "Arrays",
  "difficulty": "medium",
  "prompt": "Given an array of integers nums and an integer target, return indices of the two numbers such that they add up to target.",
  "example": ["Input: nums = [2,7,11,15], target = 9", "Output: [0,1]"],
  "constraints": ["2 <= nums.length <= 10^4", "Each input has exactly one solution"],
  "imageUrls": []
}

[https://drive.google.com/file/d/1daO2-luPvwkEYQdeH_kf81uxGbtruygM/view?usp=sharing](PostMan Test Create Question)
- GET: `http://localhost:8080/questions`

[https://drive.google.com/file/d/135Ken18rC4sa6zItLnsFq7r8JMdb8iJ4/view?usp=sharing](PostMan Test Get All Question)