### PR TITLE
feat and fix: containerize collaboration-service and fix question sort bug

### DIFF
--- a/collaboration-service/Dockerfile
+++ b/collaboration-service/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --only=production
+
+FROM node:22-alpine
+WORKDIR /app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY src ./src
+
+RUN chown -R appuser:appgroup /app
+USER appuser
+
+EXPOSE 4000
+CMD ["node", "src/index.js"]

--- a/collaboration-service/Dockerfile
+++ b/collaboration-service/Dockerfile
@@ -11,7 +11,7 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY src ./src
-
+COPY package*.json ./
 RUN chown -R appuser:appgroup /app
 USER appuser
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,3 +97,17 @@ services:
     networks:
       - peerprep-net
     restart: unless-stopped
+
+  collaboration-service:
+    build:
+      context: ./collaboration-service
+      dockerfile: Dockerfile
+    container_name: peerprep-collaboration-service
+    ports:
+      - "4000:4000"
+    environment:
+      PORT:       4000
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET must be set}
+    networks:
+      - peerprep-net
+    restart: unless-stopped

--- a/question-service/src/main/java/com/g13cs3219/questionservice/services/QuestionService.java
+++ b/question-service/src/main/java/com/g13cs3219/questionservice/services/QuestionService.java
@@ -8,16 +8,41 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Service layer for the Question Service.
+ *
+ * Handles all business logic for managing the question repository,
+ * including CRUD operations and question matching for the Matching Service.
+ * All queries are scoped to active questions only (isActive = true).
+ */
 @Service
 @RequiredArgsConstructor
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
 
+    private static final Map<String, Integer> DIFFICULTY_ORDER = Map.of(
+            "easy",   0,
+            "medium", 1,
+            "hard",   2
+    );
+
+    /**
+     * Retrieves all active questions, with optional filtering by topic and/or difficulty.
+     *
+     * - If both topic and difficulty are provided, filters by both.
+     * - If only one is provided, filters by that field only.
+     * - If neither is provided, returns all active questions.
+     *
+     * @param topic      optional topic filter (case-insensitive), e.g. "Arrays"
+     * @param difficulty optional difficulty filter (case-insensitive), e.g. "easy"
+     * @return list of matching active questions as response DTOs, sorted by difficulty (easy → medium → hard)
+     */
     public List<QuestionResponse> getQuestions(String topic, String difficulty) {
         boolean hasTopic      = topic      != null && !topic.isBlank();
         boolean hasDifficulty = difficulty != null && !difficulty.isBlank();
@@ -33,15 +58,39 @@ public class QuestionService {
             questions = questionRepository.findByIsActiveTrue();
         }
 
-        return questions.stream().map(QuestionResponse::from).collect(Collectors.toList());
+        return questions.stream()
+                .sorted(Comparator.comparingInt(q ->
+                        DIFFICULTY_ORDER.getOrDefault(q.getDifficulty().toLowerCase(), 99)))
+                .map(QuestionResponse::from)
+                .collect(Collectors.toList());
     }
 
+    /**
+     * Retrieves a single active question by its ID.
+     *
+     * @param id the question's primary key
+     * @return the question as a response DTO
+     * @throws ResponseStatusException 404 if no active question exists with the given ID
+     */
     public QuestionResponse getQuestionById(Long id) {
         Question question = questionRepository.findByQuestionIdAndIsActiveTrue(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Question not found with id: " + id));
         return QuestionResponse.from(question);
     }
 
+    /**
+     * Creates a new question and persists it to the database.
+     *
+     * Validates that all required fields (title, topic, difficulty, prompt) are present
+     * and that difficulty is one of: easy, medium, hard.
+     * Also checks that no active question with the same title already exists.
+     *
+     * @param req       the request body containing question details
+     * @param createdBy the userId of the admin performing the action
+     * @return the generated questionId of the newly created question
+     * @throws ResponseStatusException 400 if required fields are missing or difficulty is invalid
+     * @throws ResponseStatusException 409 if a question with the same title already exists
+     */
     public Long createQuestion(QuestionRequest req, Long createdBy) {
         validateRequired(req);
         validateDifficulty(req.getDifficulty());
@@ -88,6 +137,16 @@ public class QuestionService {
         questionRepository.save(question);
     }
 
+    /**
+     * Soft deletes a question by setting its isActive flag to false.
+     *
+     * The record is retained in the database to preserve referential integrity
+     * with the History table.
+     * Soft-deleted questions are excluded from all other queries.
+     *
+     * @param id the ID of the question to delete
+     * @throws ResponseStatusException 404 if no active question exists with the given ID
+     */
     public void deleteQuestion(Long id) {
         Question question = questionRepository.findByQuestionIdAndIsActiveTrue(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Question not found with id: " + id));
@@ -95,6 +154,10 @@ public class QuestionService {
         questionRepository.save(question);
     }
 
+    /**
+     * Used by Matching Service: returns one random question matching
+     * the given topic + difficulty.
+     */
     public QuestionResponse matchQuestion(String topic, String difficulty) {
         String normalizedTopic = (topic == null) ? null : topic.trim();
         if (normalizedTopic == null || normalizedTopic.isEmpty()) {
@@ -107,6 +170,12 @@ public class QuestionService {
                         "No question found for topic='" + normalizedTopic + "' difficulty='" + difficulty + "'"));
     }
 
+    /**
+     * Validates that all required fields for creating a question are present and non-blank.
+     *
+     * @param req the question creation request
+     * @throws ResponseStatusException 400 if any required field is missing
+     */
     private void validateRequired(QuestionRequest req) {
         if (req.getTitle() == null || req.getTitle().isBlank() ||
                 req.getTopic() == null || req.getTopic().isBlank() ||
@@ -116,6 +185,12 @@ public class QuestionService {
         }
     }
 
+    /**
+     * Validates that the difficulty value is one of the accepted values.
+     *
+     * @param difficulty the difficulty string to validate
+     * @throws ResponseStatusException 400 if the value is not easy, medium, or hard
+     */
     private void validateDifficulty(String difficulty) {
         if (difficulty == null || difficulty.isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "difficulty is required and must be one of: easy, medium, hard");


### PR DESCRIPTION
### Services & Ports

| user-service | http://localhost:8080 |
| question-service | http://localhost:8081 |
| collaboration-service | ws://localhost:4000 |
| user-db | localhost:5433 |
| question-db | localhost:5434 |

```bash
docker-compose up --build
```
## Fix
Questions lose their difficulty ordering (easy → medium → hard) after being updated, because PostgreSQL physically moves updated rows in the heap, causing them to appear out of order on subsequent fetches.

## Solution
Sort the result list in `QuestionService.getQuestions()` by difficulty using a `DIFFICULTY_ORDER` map (`easy=0, medium=1, hard=2`) before returning the response, ensuring consistent ordering regardless of DB row placement.

close #28 